### PR TITLE
Fixing batch export limitations

### DIFF
--- a/includes/export/abstract-wc-csv-batch-exporter.php
+++ b/includes/export/abstract-wc-csv-batch-exporter.php
@@ -45,16 +45,16 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 		$upload_dir = wp_upload_dir();
 		return trailingslashit( $upload_dir['basedir'] ) . $this->get_filename();
 	}
-	
+
 	/**
 	 * Get CSV headers row file path to export to.
 	 *
 	 * @return string
 	 */
 	protected function get_headers_row_file_path() {
-		return $this->get_file_path().".headers";
+		return $this->get_file_path() . '.headers';
 	}
-	
+
 	/**
 	 * Get the contents of the CSV headers row file. Defaults to the original known headers.
 	 *
@@ -63,7 +63,7 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 	 */
 	public function get_headers_row_file() {
 
-		$file =  chr( 239 ) . chr( 187 ) . chr( 191 ) . $this->export_column_headers();
+		$file = chr( 239 ) . chr( 187 ) . chr( 191 ) . $this->export_column_headers();
 
 		if ( @file_exists( $this->get_headers_row_file_path() ) ) { // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
 			$file = @file_get_contents( $this->get_headers_row_file_path() ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents, WordPress.WP.AlternativeFunctions.file_system_read_file_get_contents
@@ -111,7 +111,7 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 		if ( 1 === $this->get_page() ) {
 			@unlink( $this->get_file_path() ); // phpcs:ignore WordPress.VIP.FileSystemWritesDisallow.file_ops_unlink, Generic.PHP.NoSilencedErrors.Discouraged,
 
-			//we need to initialize the file here
+			// we need to initialize the file here
 			$this->get_file();
 		}
 		$this->prepare_data_to_export();
@@ -125,14 +125,14 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 	 * @param string $data Data.
 	 */
 	protected function write_csv_data( $data ) {
-		
-		if( !file_exists( $this->get_file_path() ) || !is_writeable( $this->get_file_path() ) ) {
+
+		if ( ! file_exists( $this->get_file_path() ) || ! is_writeable( $this->get_file_path() ) ) {
 			return false;
 		}
-		
-		$fp = fopen( $this->get_file_path() , "a+");
 
-		if( $fp ) {
+		$fp = fopen( $this->get_file_path(), 'a+' );
+
+		if ( $fp ) {
 			fwrite( $fp, $data );
 			fclose( $fp );
 		}
@@ -141,7 +141,7 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 		if ( 100 === $this->get_percent_complete() ) {
 			$header = chr( 239 ) . chr( 187 ) . chr( 191 ) . $this->export_column_headers();
 
-			//We need to use a temporary file to store headers, this will make our life so much easier. 
+			// We need to use a temporary file to store headers, this will make our life so much easier.
 			@file_put_contents( $this->get_headers_row_file_path(), $header ); //phpcs:ignore WordPress.VIP.FileSystemWritesDisallow.file_ops_file_put_contents, Generic.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents
 		}
 

--- a/includes/export/abstract-wc-csv-batch-exporter.php
+++ b/includes/export/abstract-wc-csv-batch-exporter.php
@@ -142,7 +142,7 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 			$header = chr( 239 ) . chr( 187 ) . chr( 191 ) . $this->export_column_headers();
 
 			//We need to use a temporary file to store headers, this will make our life so much easier. 
-			file_put_contents( $this->get_headers_row_file_path(), $header );
+			@file_put_contents( $this->get_headers_row_file_path(), $header ); //phpcs:ignore WordPress.VIP.FileSystemWritesDisallow.file_ops_file_put_contents, Generic.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents
 		}
 
 	}

--- a/includes/export/abstract-wc-csv-batch-exporter.php
+++ b/includes/export/abstract-wc-csv-batch-exporter.php
@@ -111,7 +111,7 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 		if ( 1 === $this->get_page() ) {
 			@unlink( $this->get_file_path() ); // phpcs:ignore WordPress.VIP.FileSystemWritesDisallow.file_ops_unlink, Generic.PHP.NoSilencedErrors.Discouraged,
 
-			// we need to initialize the file here
+			// We need to initialize the file here.
 			$this->get_file();
 		}
 		$this->prepare_data_to_export();

--- a/includes/export/abstract-wc-csv-batch-exporter.php
+++ b/includes/export/abstract-wc-csv-batch-exporter.php
@@ -45,6 +45,32 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 		$upload_dir = wp_upload_dir();
 		return trailingslashit( $upload_dir['basedir'] ) . $this->get_filename();
 	}
+	
+	/**
+	 * Get CSV headers row file path to export to.
+	 *
+	 * @return string
+	 */
+	protected function get_headers_row_file_path() {
+		return $this->get_file_path().".headers";
+	}
+	
+	/**
+	 * Get the contents of the CSV headers row file. Defaults to the original known headers.
+	 *
+	 * @since 3.1.0
+	 * @return string
+	 */
+	public function get_headers_row_file() {
+
+		$file =  chr( 239 ) . chr( 187 ) . chr( 191 ) . $this->export_column_headers();
+
+		if ( @file_exists( $this->get_headers_row_file_path() ) ) { // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
+			$file = @file_get_contents( $this->get_headers_row_file_path() ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents, WordPress.WP.AlternativeFunctions.file_system_read_file_get_contents
+		}
+
+		return $file;
+	}
 
 	/**
 	 * Get the file contents.
@@ -70,8 +96,9 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 	 */
 	public function export() {
 		$this->send_headers();
-		$this->send_content( $this->get_file() );
+		$this->send_content( $this->get_headers_row_file() . $this->get_file() );
 		@unlink( $this->get_file_path() ); // phpcs:ignore WordPress.VIP.FileSystemWritesDisallow.file_ops_unlink, Generic.PHP.NoSilencedErrors.Discouraged
+		@unlink( $this->get_headers_row_file_path() ); // phpcs:ignore WordPress.VIP.FileSystemWritesDisallow.file_ops_unlink, Generic.PHP.NoSilencedErrors.Discouraged
 		die();
 	}
 
@@ -83,6 +110,9 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 	public function generate_file() {
 		if ( 1 === $this->get_page() ) {
 			@unlink( $this->get_file_path() ); // phpcs:ignore WordPress.VIP.FileSystemWritesDisallow.file_ops_unlink, Generic.PHP.NoSilencedErrors.Discouraged,
+
+			//we need to initialize the file here
+			$this->get_file();
 		}
 		$this->prepare_data_to_export();
 		$this->write_csv_data( $this->get_csv_data() );
@@ -95,15 +125,26 @@ abstract class WC_CSV_Batch_Exporter extends WC_CSV_Exporter {
 	 * @param string $data Data.
 	 */
 	protected function write_csv_data( $data ) {
-		$file = $this->get_file();
+		
+		if( !file_exists( $this->get_file_path() ) || !is_writeable( $this->get_file_path() ) ) {
+			return false;
+		}
+		
+		$fp = fopen( $this->get_file_path() , "a+");
 
-		// Add columns when finished.
-		if ( 100 === $this->get_percent_complete() ) {
-			$file = chr( 239 ) . chr( 187 ) . chr( 191 ) . $this->export_column_headers() . $file;
+		if( $fp ) {
+			fwrite( $fp, $data );
+			fclose( $fp );
 		}
 
-		$file .= $data;
-		@file_put_contents( $this->get_file_path(), $file ); // phpcs:ignore WordPress.VIP.FileSystemWritesDisallow.file_ops_file_put_contents, Generic.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents
+		// Add all columns when finished.
+		if ( 100 === $this->get_percent_complete() ) {
+			$header = chr( 239 ) . chr( 187 ) . chr( 191 ) . $this->export_column_headers();
+
+			//We need to use a temporary file to store headers, this will make our life so much easier. 
+			file_put_contents( $this->get_headers_row_file_path(), $header );
+		}
+
 	}
 
 	/**


### PR DESCRIPTION
This commit will fix the batch export issues related to distributed file systems and memory limitations.

Basically, instead of pretending the headers at the last step of the export and loading the full CSV content into memory each time data needs to be added, we basically will append the data to the created file on each batch request; and at the last step, we will also create a temporary file to store the CSV headers, so when preparing the download to the user, this will simply read the CSV headers from the created temporary file.

### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
